### PR TITLE
fix: correctly deserialize `undefined`

### DIFF
--- a/src/typedjson.test.ts
+++ b/src/typedjson.test.ts
@@ -181,4 +181,7 @@ describe('serialize and deserialize', () => {
     const result = deserialize<typeof obj>({ json, meta })
     expect(result).toEqual(obj)
   })
+  it('works for undefined', () => {
+    expect(deserialize(serialize(undefined)!)).toBeUndefined()
+  })
 })

--- a/src/typedjson.ts
+++ b/src/typedjson.ts
@@ -114,6 +114,9 @@ function serialize<T>(data: T): TypedJsonResult | null {
 }
 
 function deserialize<T>({ json, meta }: TypedJsonResult): T | null {
+  if (typeof json === 'undefined') {
+    return undefined as unknown as T
+  }
   if (!json) return null
   const result = JSON.parse(json)
   if (meta) {


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/Skn0tt/remix-typedjson/undefined?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=Skn0tt&repo=remix-typedjson&branch=undefined">VS Code</a>

<!-- open-in-codesandbox:complete -->


Hi @kiliman, what a wonderful project!
While reading through the source code, I spotted a minor bug with the 
serialisation of `undefined`. This PR fixes that.

