### PR TITLE
add React 18 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   "peerDependencies": {
     "@remix-run/react": "^1.6.5",
     "@remix-run/server-runtime": "^1.6.5",
-    "react": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0"
   }
 }


### PR DESCRIPTION
Allow package installation without the `--force` or `--legacy-peer-deps` flags in projects using React 18