### PR TITLE
export TypedFetcherWithComponents type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,11 @@ export {
   useTypedFetcher,
   useTypedLoaderData,
 } from './remix'
-export type { TypedJsonResponse, TypedMetaFunction } from './remix'
+export type {
+  TypedJsonResponse,
+  TypedMetaFunction,
+  TypedFetcherWithComponents,
+} from './remix'
 export {
   applyMeta,
   deserialize,

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -65,7 +65,10 @@ export function useTypedActionData<
   ) as UseDataFunctionReturn<T> | null
 }
 
-type TypedFetcherWithComponents<T> = Omit<FetcherWithComponents<T>, 'data'> & {
+export type TypedFetcherWithComponents<T> = Omit<
+  FetcherWithComponents<T>,
+  'data'
+> & {
   data: UseDataFunctionReturn<T>
 }
 export function useTypedFetcher<T>(): TypedFetcherWithComponents<T> {


### PR DESCRIPTION
Exporting the `TypedFetcherWithComponents` comes handy, when you would like to pass around a fetcher in react components and you would like to type those components.

Also, it's [exported](https://github.com/remix-run/remix/blob/cb7416beb87f2f008f05bafb0c25d263bf59851f/packages/remix-react/components.tsx#L1448-L1455) in the `remix-react` base package as well.
