### PR TITLE
🔨 Export `UseDataFunctionReturn` & `RemixSerializedType` types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type {
   TypedJsonResponse,
   TypedMetaFunction,
   TypedFetcherWithComponents,
+  UseDataFunctionReturn
 } from './remix'
 export {
   applyMeta,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,10 @@ export {
   useTypedActionData,
   useTypedFetcher,
   useTypedLoaderData,
+  
 } from './remix'
 export type {
+  RemixSerializedType,
   TypedJsonResponse,
   TypedMetaFunction,
   TypedFetcherWithComponents,

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -80,7 +80,7 @@ export function useTypedFetcher<T>(): TypedFetcherWithComponents<T> {
   return fetcher as TypedFetcherWithComponents<T>
 }
 
-type RemixSerializedType<T> = {
+export type RemixSerializedType<T> = {
   __obj__: T | null
   __meta__?: MetaType | null
 } & (T | { __meta__?: MetaType })


### PR DESCRIPTION
Related to conversation https://github.com/kiliman/remix-typedjson/issues/18 - exports the `UseDataFunctionReturn` type which makes typing a `loader` response when consumed via `useMatches` and should be helpful in concert with the `useRouteLoaderData` function.