### PR TITLE
Add `useTypedCatch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ get the correct type inference.
 const actionData = useTypedActionData<typeof action>()
 ```
 
+## `useTypedCatch`
+
+Replacement for Remix `useCatch`. Use to deserialize [thrown](https://remix.run/docs/en/v1/route/loader#throwing-responses-in-loaders) `typeJson` responses.
+
+#### Usage
+
+```js
+const caught = useTypedCatch<ThrownResponse<404, CatchData>>()
+```
+
 ## `useTypedRouteLoaderData`
 
 Helper for `useMatches` that returns the route data based on provided route `id`

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
   stringifyRemix,
   typedjson,
   useTypedActionData,
+  useTypedCatch,
   useTypedFetcher,
   useTypedLoaderData,
   useTypedRouteLoaderData,

--- a/src/remix.ts
+++ b/src/remix.ts
@@ -1,7 +1,9 @@
 import {
   HtmlMetaDescriptor,
   Params,
+  ThrownResponse,
   useActionData,
+  useCatch,
   useFetcher,
   useLoaderData,
   useMatches,
@@ -64,6 +66,17 @@ export function useTypedActionData<
   return deserializeRemix<T>(
     data as RemixSerializedType<T>,
   ) as UseDataFunctionReturn<T> | null
+}
+export function useTypedCatch<
+  Result extends ThrownResponse = ThrownResponse,
+>(): Result {
+  const caught = useCatch<
+    Omit<Result, `data`> & { data: RemixSerializedType<Result[`data`]> }
+  >()
+  return {
+    ...caught,
+    data: deserializeRemix<Result[`data`]>(caught.data),
+  } as Result
 }
 
 export type TypedFetcherWithComponents<T> = Omit<


### PR DESCRIPTION
[`useCatch`](https://remix.run/docs/en/v1/route/catch-boundary) can receive data too! This makes so that if someone throws a `typedJson` response, then they can catch it and deserialize it.

Aside: noticed that there's a `lint` script, but `eslint` is not installed and there's no config so I couldn't lint my changes.