### PR TITLE
add support for decimal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "remix-typedjson",
       "version": "0.1.7",
       "license": "MIT",
+      "dependencies": {
+        "decimal.js": "^10.4.3"
+      },
       "devDependencies": {
         "@babel/core": "^7.16.0",
         "@babel/preset-env": "^7.16.4",
@@ -3079,10 +3082,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
-      "dev": true
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -9002,10 +9004,9 @@
       "dev": true
     },
     "decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
-      "dev": true
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "dedent": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "@remix-run/react": "^1.6.5",
     "@remix-run/server-runtime": "^1.6.5",
     "react": "^17.0.2 || ^18.0.0"
+  },
+  "dependencies": {
+    "decimal.js": "^10.4.3"
   }
 }

--- a/src/typedjson.test.ts
+++ b/src/typedjson.test.ts
@@ -1,3 +1,4 @@
+import Decimal from 'decimal.js'
 import { deserialize, serialize, stringify } from './typedjson'
 
 describe('serialize and deserialize', () => {
@@ -57,9 +58,7 @@ describe('serialize and deserialize', () => {
     const obj = new Set([1, undefined, 2])
 
     const { json, meta } = serialize(obj)
-    //console.log(json, meta)
     const result = deserialize({ json, meta })
-    //console.log(result)
     expect(result).toEqual(obj)
   })
   it('works for simple Maps', () => {
@@ -189,11 +188,22 @@ describe('serialize and deserialize', () => {
     const result = deserialize<typeof obj>({ json, meta })
     expect(result).toEqual(obj)
   })
+  it('works for Decimal', () => {
+    const obj = {
+      a: new Decimal(22.5),
+    }
+    const { json, meta } = serialize(obj)
+    expect(json).toEqual('{"a":"22.5"}')
+    expect(meta).toEqual({ a: 'decimal' })
+    const result = deserialize<typeof obj>({ json, meta })
+    expect(result).toEqual(obj)
+  })
+
   it('works for undefined', () => {
     expect(deserialize(serialize(undefined)!)).toBeUndefined()
   })
 
-  it.only('works for serialize output arguments', () => {
+  it('works for serialize output arguments', () => {
     const test = {
       bi: BigInt('1021312312412312312313'),
       nan: NaN,
@@ -201,13 +211,15 @@ describe('serialize and deserialize', () => {
         P: Number.POSITIVE_INFINITY,
         N: Number.NEGATIVE_INFINITY,
       },
-      d: new Date(Date.UTC(1979, 0, 10))
+      d: new Date(Date.UTC(1979, 0, 10)),
     }
 
     const strStd = stringify(test)
     const strDbg = stringify(test, null, 2)
 
-    expect(strStd).toBe("{\"json\":\"{\\\"bi\\\":\\\"1021312312412312312313\\\",\\\"nan\\\":\\\"NaN\\\",\\\"inf\\\":{\\\"P\\\":\\\"Infinity\\\",\\\"N\\\":\\\"-Infinity\\\"},\\\"d\\\":\\\"1979-01-10T00:00:00.000Z\\\"}\",\"meta\":{\"bi\":\"bigint\",\"nan\":\"nan\",\"inf.P\":\"infinity\",\"inf.N\":\"-infinity\",\"d\":\"date\"}}")
+    expect(strStd).toBe(
+      '{"json":"{\\"bi\\":\\"1021312312412312312313\\",\\"nan\\":\\"NaN\\",\\"inf\\":{\\"P\\":\\"Infinity\\",\\"N\\":\\"-Infinity\\"},\\"d\\":\\"1979-01-10T00:00:00.000Z\\"}","meta":{"bi":"bigint","nan":"nan","inf.P":"infinity","inf.N":"-infinity","d":"date"}}',
+    )
     expect(strDbg).toBe(`{
   "json": {
     "bi": "1021312312412312312313",

--- a/src/typedjson.ts
+++ b/src/typedjson.ts
@@ -20,7 +20,6 @@ type EntryType = {
   iteration: number
 }
 function serialize<T>(data: T): TypedJsonResult {
-  console.log('HI GARRETT')
   if (data === null) return { json: 'null' }
   if (data === undefined) return { json: undefined }
 

--- a/src/typedjson.ts
+++ b/src/typedjson.ts
@@ -20,6 +20,7 @@ type EntryType = {
   iteration: number
 }
 function serialize<T>(data: T): TypedJsonResult {
+  console.log('HI GARRETT')
   if (data === null) return { json: 'null' }
   if (data === undefined) return { json: undefined }
 

--- a/src/typedjson.ts
+++ b/src/typedjson.ts
@@ -52,6 +52,9 @@ function serialize<T>(data: T): TypedJsonResult {
       if (value instanceof Date) {
         t = 'date'
         value = value.toISOString()
+      } else if (Decimal.isDecimal(value)) {
+        t = 'decimal'
+        value = value.toJSON()
       } else if (value instanceof Set) {
         value = Array.from(value)
         count = value.length
@@ -66,9 +69,6 @@ function serialize<T>(data: T): TypedJsonResult {
       } else if (value instanceof RegExp) {
         t = 'regexp'
         value = String(value)
-      } else if (value instanceof Decimal) {
-        t = 'decimal'
-        value = value.toJSON()
       } else if (value instanceof Error) {
         t = 'error'
         value = { name: value.name, message: value.message, stack: value.stack }


### PR DESCRIPTION
This PR adds support for the [Decimal](https://mikemcl.github.io/decimal.js/) datatype. 

I followed the same approach as the [contribution to superjson](https://github.com/blitz-js/superjson/pull/158/files) to just call `toJSON` for serialization. 

Also removed a rogue `.only` on the typed tests so they all run. 

Let me know if there's anything you want changed :) 