### PR TITLE
Meta keys can be incorrect when there is an empty string property

### DIFF
--- a/src/remix.test.ts
+++ b/src/remix.test.ts
@@ -25,6 +25,18 @@ describe('stringify Remix data', () => {
         '"__meta__":{"0.bigint":"bigint","1.bigint":"bigint"}}',
     )
   })
+  it('works for this edge case', () => {
+    const edgeCase = {
+      nested: {
+        '': [{}],
+        bigint: BigInt(1),
+      },
+    }
+    const json = stringifyRemix(edgeCase)
+    expect(json).toEqual(
+      '{"nested":{"":[{}],"bigint":"1"},"__meta__":{"nested.bigint":"bigint"}}',
+    )
+  })
 })
 describe('deserialize Remix data', () => {
   it('works for JSON only objects', () => {


### PR DESCRIPTION
Recently tracked down this weird edge case where there is a nested object with a key that is an empty string and the value is `[{}]` resulting in meta keys being incorrect after the serialization encounters it. I've added this test case that recreates it. 

The offending data here:

```ts
const edgeCase = { 
 nested: {
    '': [{}],
     bigint: BigInt(1),
  },
}
```

The expected value is 

```
'{"nested":{"":[{}],"bigint":"1"},"__meta__":{"nested.bigint":"bigint"}}'
```

But the actual is:

```
'{"nested":{"":[{}],"bigint":"1"},"__meta__":{"bigint":"bigint"}}'
```